### PR TITLE
Enable video recording with row-labeling

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -75,7 +75,11 @@
     The formatting for how the images are stored should be tweaked to fit your needs. Currently the \
     files get overridden each render
 
-11. **Dumping Properties:**
+11. **Taking Video:**
+    - Enable `Take video` and specify a directory and frame count.
+    - Click `TAKE VIDEO` to record a labeled and unlabeled video along the sine wave path.
+
+12. **Dumping Properties:**
     - All properties are saved to a JSON file in the `dumps' directory with a timestamp for future reference.
 
 ### JSON Configuration

--- a/addon/orchard_generator/__init__.py
+++ b/addon/orchard_generator/__init__.py
@@ -32,7 +32,7 @@ from .image_panel import MY_PT_RenderImagesPanel
 
 from . props import MyProperties
 
-from . ops import GenerateOrchardOperator, OBJECT_OT_take_image
+from . ops import GenerateOrchardOperator, OBJECT_OT_take_image, OBJECT_OT_take_video
 
 classes = (
     MY_PT_OrchardPanel,
@@ -41,7 +41,8 @@ classes = (
     MY_PT_RenderImagesPanel,
     MyProperties,
     GenerateOrchardOperator,
-    OBJECT_OT_take_image
+    OBJECT_OT_take_image,
+    OBJECT_OT_take_video
 )
 
 def register():

--- a/addon/orchard_generator/image_panel.py
+++ b/addon/orchard_generator/image_panel.py
@@ -18,11 +18,13 @@ class MY_PT_RenderImagesPanel(Panel):
 
         row = layout.row()
         row.operator("object.take_images")
+        row.operator("object.take_video")
 
         row = layout.row(align=True)
         row.prop(props, "snap_image")
         row.prop(props, "random_tree")
         row.prop(props, "image_pairs")
+        row.prop(props, "make_video")
 
         if props.snap_image:
             row = layout.row()
@@ -41,6 +43,12 @@ class MY_PT_RenderImagesPanel(Panel):
             row = layout.row()
             row.prop(props, "resolution_X")
             row.prop(props, "resolution_Y")
+
+        if props.make_video:
+            row = layout.row()
+            row.prop(props, "video_dir_path")
+            row = layout.row()
+            row.prop(props, "video_frame_count")
         
         layout.label(text="Camera extrinsics:")
         row = layout.row()

--- a/addon/orchard_generator/ops.py
+++ b/addon/orchard_generator/ops.py
@@ -1,6 +1,6 @@
 import bpy
 from . load_script_label import render
-from . generate_images import take_images
+from . generate_images import take_images, take_video
 
 class GenerateOrchardOperator(bpy.types.Operator):
     """Calls the render function to generate orchard"""
@@ -26,6 +26,21 @@ class OBJECT_OT_take_image(bpy.types.Operator):
 
     def execute(self, context):
         take_images(self, context)
+        return {'FINISHED'}
+
+
+class OBJECT_OT_take_video(bpy.types.Operator):
+    """Render video following the sine path"""
+    bl_idname = "object.take_video"
+    bl_label = "TAKE VIDEO"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.my_tool.make_video and context.scene.my_tool.orchard_generated
+
+    def execute(self, context):
+        take_video(self, context)
         return {'FINISHED'}
 
 

--- a/addon/orchard_generator/props.py
+++ b/addon/orchard_generator/props.py
@@ -163,6 +163,26 @@ Useful for adjusting desired camera parameters""",
         default= False,
     )
 
+    make_video: bpy.props.BoolProperty(
+        name="Take video",
+        description="Toggle on to record a video instead of images",
+        default=False,
+    )
+
+    video_dir_path: bpy.props.StringProperty(
+        name="Video dir path",
+        description="Select the directory to store the rendered video",
+        default="path to dir for video storage...",
+        maxlen=1024,
+        subtype="DIR_PATH")
+
+    video_frame_count: bpy.props.IntProperty(
+        name="Video frames",
+        description="Number of frames in the output video",
+        default=250,
+        min=1,
+    )
+
     image_dir_path: bpy.props.StringProperty(
         name="Images dir path",
         description="Select the directory to store images taken",


### PR DESCRIPTION
## Summary
- add video recording operator and path animation
- label an entire tree row during rendering
- expose video options in the UI
- register new operator and properties
- document new video workflow

## Testing
- `python -m py_compile addon/orchard_generator/generate_images.py addon/orchard_generator/ops.py addon/orchard_generator/props.py addon/orchard_generator/image_panel.py addon/orchard_generator/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684a6e6c7cb483218e64beea133fa542